### PR TITLE
Trigger automatically every day via cron

### DIFF
--- a/worker/src/api/discordWebhook.ts
+++ b/worker/src/api/discordWebhook.ts
@@ -1,0 +1,12 @@
+import { DiscordWebhookPayload } from "../types"
+
+export async function pushToWebhook(url: string, payload: DiscordWebhookPayload): Promise<void> {
+  await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+}

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -15,3 +15,12 @@ export interface DiscordApplicationCommand {
   name: string,
   type: unknown
 }
+
+export interface DiscordWebhookEmbed {
+	image: { url: string }
+}
+
+export interface DiscordWebhookPayload {
+	embeds: Array<DiscordWebhookEmbed>
+}
+

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -2,3 +2,6 @@ name = "worker"
 main = "src/index.ts"
 compatibility_date = "2024-01-17"
 compatibility_flags = [ "nodejs_compat" ]
+
+[triggers]
+crons = ["0 14 * * *"]


### PR DESCRIPTION
Adds a ScheduledEvent that will trigger each day at 14:00 UTC, will get a duck, and will sent it to a previously designated Discord channel via a Discord webhook.

Webhooks are the outgoing HTTP request equivalent to interactions, which are incoming HTTP requests. They have a very similar payload, but not 100% equivalent.

---

**To actually activate this**

Go to the channel and press the cog button:

![image](https://github.com/Niv3K-El-Pato/ElPatoOraculo/assets/1568690/dcab4b5b-d276-4fe6-b92a-053c44537cdb)

Go to Integrations - Webhooks

![image](https://github.com/Niv3K-El-Pato/ElPatoOraculo/assets/1568690/2446e3b2-030c-458a-83d2-64fff25e0737)

Click New Webhook to create a new webhook, and then click it to open the settings

![image](https://github.com/Niv3K-El-Pato/ElPatoOraculo/assets/1568690/d4a175d2-19a9-492c-99c1-c853a5f35dc9)

Give it the same name and icon as the application, remember to save changes

![image](https://github.com/Niv3K-El-Pato/ElPatoOraculo/assets/1568690/3358b08b-2aa7-458f-97fb-ad8440f40401)

But most importantly, click "Copy Webhook URL", this should copy to your clipboard an URL that starts with `https://discord.com/api/webhooks/`. Go to the Cloudflare Worker used for the production patoráculo, and in settings, create an environment variable called `WEBHOOK_URL` with that value.

![image](https://github.com/Niv3K-El-Pato/ElPatoOraculo/assets/1568690/893bd4e5-9ed0-4df8-9df1-fc0cfb10b146)
