### PR TITLE
Add lucky mode

### DIFF
--- a/worker/src/api/catApi.ts
+++ b/worker/src/api/catApi.ts
@@ -1,0 +1,19 @@
+const catErrorCodeUrl = (code: number) => `https://http.cat/images/${code}.jpg`;
+
+const getRandomCatUrl = async (): Promise<string> => {
+    try {
+        const resp = await fetch('https://cataas.com/cat?json=true');
+        const { _id } = await resp.json() as { _id: string };
+
+        if (!_id) return catErrorCodeUrl(resp.status);
+
+        return `https://cataas.com/cat/${_id}`;
+    } catch {
+        return catErrorCodeUrl(500);
+    }
+};
+
+export const CatApi = {
+    getRandomCatUrl,
+    catErrorCodeUrl,
+};


### PR DESCRIPTION
This commit will make the /quack command have a 0.1% chance of responding with a cat image instead of a duck image.

## Why?

Why not.

## Implementation details

It uses the **Cat as a service** API (CATAAS) to return a random cat. The API is not as pleasant as random-d.uk, but you can get a random photo ID and then a photo lookup anyway.

## Notes

Unlike random-d.uk, which sometimes returns geese instead of ducks, I haven't seen pictures of pantheras, tigers, leopards, jaguars, lynxs, pumas, lions, servals, cheetahs, ocelots, caracals, bengala cats, margays, dogs or ducks yet in the API response.

However, the infrastructure would be there to ban images by ID in case something that is not a cat is ever returned by the API.